### PR TITLE
Feature/unused flagz

### DIFF
--- a/flagz-java/src/main/java/org/flagz/BaseFlag.java
+++ b/flagz-java/src/main/java/org/flagz/BaseFlag.java
@@ -2,6 +2,8 @@ package org.flagz;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.LinkedList;
@@ -17,12 +19,15 @@ import java.util.function.Predicate;
  */
 class BaseFlag<T> implements Flag<T> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(FlagFieldRegistry.class);
+
   private volatile T value;
   private final T defaultValue;
 
   protected String name;
   protected String altName;
   protected String help;
+  protected boolean unusedMarker;
 
   private final List<Predicate<T>> validators = new LinkedList<>();
   private final List<Consumer<T>> listeners = new LinkedList<>();
@@ -34,6 +39,10 @@ class BaseFlag<T> implements Flag<T> {
 
   @Override
   public T get() {
+    if (unusedMarker) {
+      String errMsg = String.format("Trying to get a value from flag: %s, which is marked as unused.", name);
+      LOG.error(errMsg);
+    }
     return value;
   }
 

--- a/flagz-java/src/main/java/org/flagz/FlagField.java
+++ b/flagz-java/src/main/java/org/flagz/FlagField.java
@@ -63,6 +63,7 @@ public abstract class FlagField<T> extends BaseFlag<T> {
     // Extract the Class<X> or ParametrizedType<X> from Flag<X>
     this.containingFieldType = ((ParameterizedType) containingField.getGenericType())
         .getActualTypeArguments()[0];
+    this.unusedMarker = containingField.isAnnotationPresent(FlagzUnused.class);
   }
 
   Field containingField() {

--- a/flagz-java/src/main/java/org/flagz/FlagzUnused.java
+++ b/flagz-java/src/main/java/org/flagz/FlagzUnused.java
@@ -1,0 +1,17 @@
+package org.flagz;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation used on fields of type Flag<?> to indicate that their value is never read (and, as
+ * such, it is useless to specify them). Note that this is subtly stronger than {@link Deprecated}
+ * in that deprecated flags might still be read whereas {@link FlagzUnused} may not.
+ *
+ * Any attempt to get a value from an unused flag will raise a {@link RuntimeException}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface FlagzUnused {}

--- a/flagz-java/src/main/java/org/flagz/Utils.java
+++ b/flagz-java/src/main/java/org/flagz/Utils.java
@@ -25,13 +25,17 @@ class Utils {
     builder.append("List of Flagz available in this program:\n");
     builder.append("\n");
     for (FlagField<?> field : sorted) {
-      String flag = Strings.isNullOrEmpty(field.altName())
-          ? String.format("--%s", field.name())
-          : String.format("--%s [-%s]", field.name(), field.altName());
+      String flag = flagDescriptorString(field);
       builder.append(String.format("%-35s\t%s\t[default='%s']\n", flag, field.help(),
                                    flagDefaultValue(field)));
     }
     System.out.println(builder.toString());
+  }
+
+  static String flagDescriptorString(FlagField<?> field) {
+    return Strings.isNullOrEmpty(field.altName())
+        ? String.format("--%s", field.name())
+        : String.format("--%s [-%s]", field.name(), field.altName());
   }
 
   /**

--- a/flagz-java/src/test/java/org/flagz/PrimitiveFlagFieldTest.java
+++ b/flagz-java/src/test/java/org/flagz/PrimitiveFlagFieldTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import org.flagz.testclasses.SomeEnum;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 

--- a/flagz-java/src/test/java/org/flagz/UnusedFlagTest.java
+++ b/flagz-java/src/test/java/org/flagz/UnusedFlagTest.java
@@ -1,0 +1,116 @@
+package org.flagz;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for validator and listener functionality of {@link BaseFlag}.
+ */
+public class UnusedFlagTest {
+
+  public static final List<String> EMPTY_PACKAGE_PREFIXES = ImmutableList.of();
+  private UsedFlags usedFlags = new UsedFlags();
+  private UnusedFlags unusedFlags = new UnusedFlags();
+  private Set<Object> onlyUsed = ImmutableSet.of(usedFlags);
+  private Set<Object> onlyUnused = ImmutableSet.of(unusedFlags);
+  private Set<Object> mixed = ImmutableSet.of(usedFlags, unusedFlags);
+
+  @Test
+  public void testNoParsingAllFlagsAvailable() {
+    String[] args = {};
+    FlagFieldRegistry registry = Flagz.parse(args, EMPTY_PACKAGE_PREFIXES, mixed);
+    Set<FlagField<?>> unused = registry.unusedFlags(Utils.parseArgsToFieldMap(args));
+    assertThat(unused.isEmpty(), is(true));
+  }
+
+  @Test
+  public void testNoParsingUnusedFlagsAvailable() {
+    String[] args = {};
+    FlagFieldRegistry registry = Flagz.parse(args, EMPTY_PACKAGE_PREFIXES, onlyUnused);
+    Set<FlagField<?>> unused = registry.unusedFlags(Utils.parseArgsToFieldMap(args));
+    assertThat(unused.isEmpty(), is(true));
+  }
+
+  @Test
+  public void testNoParsingUsedFlagsAvailable() {
+    String[] args = {};
+    FlagFieldRegistry registry = Flagz.parse(args, EMPTY_PACKAGE_PREFIXES, onlyUsed);
+    Set<FlagField<?>> unused = registry.unusedFlags(Utils.parseArgsToFieldMap(args));
+    assertThat(unused.isEmpty(), is(true));
+  }
+
+  @Test
+  public void testParsingOnlyUsedFlags() {
+    String[] args = {"--test_flag_int=101010", "--test_flag_string=hi", "--test_flag_float=200.0"};
+    FlagFieldRegistry registry = Flagz.parse(args, EMPTY_PACKAGE_PREFIXES, onlyUsed);
+    Set<FlagField<?>> unused = registry.unusedFlags(Utils.parseArgsToFieldMap(args));
+    assertThat(unused.isEmpty(), is(true));
+  }
+
+  @Test
+  public void testParsingOnlyUnusedFlags() {
+    String[] args = {"--test_flag_other_int=101010", "--test_flag_other_string=hi", "--test_flag_other_float=200.0"};
+    FlagFieldRegistry registry = Flagz.parse(args, EMPTY_PACKAGE_PREFIXES, onlyUnused);
+    Set<FlagField<?>> unused = registry.unusedFlags(Utils.parseArgsToFieldMap(args));
+    assertThat(unused.size(), is(3));
+  }
+
+  @Test
+  public void testParsingMixedFlags() {
+    String[] args = {"--test_flag_int=101010", "--test_flag_string=hi", "--test_flag_float=200.0",
+        "--test_flag_other_int=101010", "--test_flag_other_string=hi", "--test_flag_other_float=200.0"};
+    FlagFieldRegistry registry = Flagz.parse(args, EMPTY_PACKAGE_PREFIXES, mixed);
+    Set<FlagField<?>> unused = registry.unusedFlags(Utils.parseArgsToFieldMap(args));
+    assertThat(unused.size(), is(3));
+  }
+
+  @Test
+  public void testCorrectStringProduced() {
+    String[] args = {"--test_flag_int=101010", "--test_flag_string=hi", "--test_flag_float=200.0",
+        "--test_flag_other_int=101010", "--test_flag_other_string=hi", "--test_flag_other_float=200.0"};
+    String[] expectedMessage =
+        {"The following flag is unused - it will have no effect on the system: --test_flag_other_int [-tfoi]",
+            "The following flag is unused - it will have no effect on the system: --test_flag_other_string",
+            "The following flag is unused - it will have no effect on the system: --test_flag_other_float [-tfof]"};
+    FlagFieldRegistry registry = Flagz.parse(args, EMPTY_PACKAGE_PREFIXES, mixed);
+    Set<FlagField<?>> unused = registry.unusedFlags(Utils.parseArgsToFieldMap(args));
+    String[] generatedMessage = FlagFieldRegistry.unusedFlagsMessages(unused);
+    Arrays.sort(expectedMessage);
+    Arrays.sort(generatedMessage);
+    assertThat(generatedMessage, is(expectedMessage));
+  }
+
+  static class UsedFlags {
+    @FlagInfo(name = "test_flag_int", help = "some int")
+    public final Flag<Integer> flagInt = Flagz.valueOf(200);
+
+    @FlagInfo(name = "test_flag_string", help = "some string")
+    public final Flag<String> flagStr = Flagz.valueOf("test");
+
+    @FlagInfo(name = "test_flag_float", help = "some float")
+    public final Flag<Float> flagFloat = Flagz.valueOf(200.0f);
+  }
+
+  static class UnusedFlags {
+    @FlagzUnused
+    @FlagInfo(name = "test_flag_other_int", altName = "tfoi", help = "some other int")
+    public final Flag<Integer> flagOtherInt = Flagz.valueOf(100);
+
+    @FlagzUnused
+    @FlagInfo(name = "test_flag_other_string", help = "some other string")
+    public final Flag<String> flagOtherStr = Flagz.valueOf("other test");
+
+    @FlagzUnused
+    @FlagInfo(name = "test_flag_other_float", altName = "tfof", help = "some other float")
+    public final Flag<Float> flagOtherFloat = Flagz.valueOf(100.0f);
+  }
+
+}


### PR DESCRIPTION
Adds the FlagzUnused annotation to mark flags as unused. 
When Flagz detects that a flag is marked as unused, it will proceed as normal and warn the user that the flag will not have any effect on the system.
